### PR TITLE
Admin settings templates

### DIFF
--- a/management_app/__init__.py
+++ b/management_app/__init__.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from . import db
 from .views.auth import auth
 from .views.faculty import faculty
+from .views.settings import settings
 
 load_dotenv('.flaskenv')
 load_dotenv('.env')
@@ -34,6 +35,7 @@ def create_app(test_config=None):
 
     app.register_blueprint(auth)
     app.register_blueprint(faculty) # temporarily render faculty views under url_prefix='/faculty'
+    app.register_blueprint(settings) # temporarily render settings views under url_prefix='/settings'
 
     @app.route('/')
     def redirect_to_auth_login():

--- a/management_app/templates/base.html
+++ b/management_app/templates/base.html
@@ -48,8 +48,6 @@
               <i class="fa-regular fa-face-smile"></i>
             </a>
             <ul class="dropdown-menu text-small shadow">
-              <li><a class="dropdown-item" href="#">Manage Admins</a></li>
-              <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item" href="/auth/logout">Logout</a></li>
             </ul>
           </div>
@@ -57,8 +55,9 @@
       </nav>
 
       <section class="content">
-        <header>
+        <header class="d-flex gap-3">
           <h1>{% block header %}{% endblock %}</h1>
+          {% block header_content %}{% endblock %}
         </header>
 
         {% block content %}{% endblock %}

--- a/management_app/templates/settings/admins.html
+++ b/management_app/templates/settings/admins.html
@@ -1,0 +1,119 @@
+{% extends 'base.html' %}
+
+{% block title %}Settings{% endblock %}
+{% block header %}Settings{% endblock %}
+
+{% block header_content %}
+  <nav class="navbar navbar-expand-sm bg-light">
+    <div class="container-fluid">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="/settings/admins">Admins</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/settings/point-policy">Point Policy</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+{% endblock %}
+
+{% block content %}
+  <div class="container">
+    <div class="d-grid justify-content-end">
+      <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addModal">+ Add Admin</button>
+    </div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Email</th>
+          <th scope="col"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for admin in admins %}
+          <tr>
+            <th scope="row">{{admin['name']}} {% if admin == current_user %}<span class="badge text-bg-primary">You</span>{% endif %}</th>
+            <td>{{admin['email']}}</td>
+            <td>
+              <div class="dropdown d-grid justify-content-end">
+                <button class="btn btn-secondary fw-bold" type="button" data-bs-toggle="dropdown" aria-expanded="false">⋮</button>
+                <ul class="dropdown-menu">
+                  <li>
+                    <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="{{'#deleteModalSelf' if admin == current_user else '#deleteModal'}}">
+                      <i class="fa-solid fa-trash"></i></i> Delete
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="modal fade" id="addModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addModalTitle" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title fs-5" id="addModalTitle">Add Admin</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <label for="userSelect">Select a user to make an admin</label>
+            <select class="form-select" id="userSelect" aria-label="User Selection">
+              <option selected>Select a user</option>
+              {% for user in users %}
+                <option value="{{user['name']}}">{{user['name']}}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <!-- TODO enable button when a user is selected -->
+            <button type="button" class="btn btn-primary" disabled>Add Admin</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal fade" id="deleteModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="deleteModalTitle" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title fs-5" id="deleteModalTitle">Delete Admin</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>Are you sure you want to delete this admin?</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+            <button type="button" class="btn btn-primary">Yes</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal fade" id="deleteModalSelf" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="deleteModalSelfTitle" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title fs-5" id="deleteModalSelfTitle">Delete My Account</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>Are you sure you want to delete your account? This action cannot be undone.</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+            <button type="button" class="btn btn-primary">Yes</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/management_app/templates/settings/point-policy.html
+++ b/management_app/templates/settings/point-policy.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block title %}Settings{% endblock %}
+{% block header %}Settings{% endblock %}
+
+{% block header_content %}
+  <nav class="navbar navbar-expand-sm bg-light">
+    <div class="container-fluid">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="/settings/admins">Admins</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active" href="/settings/point-policy">Point Policy</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+{% endblock %}
+
+{% block content %}
+  <div class="container">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Rule</th>
+          <th scope="col">Point Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for rule in rules %}
+          <tr>
+            <th scope="row">{{rule['name']}}</th>
+            <td>{{rule['point_value']}}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/management_app/views/settings.py
+++ b/management_app/views/settings.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, render_template
+
+from management_app.views.auth import login_required
+
+settings = Blueprint('settings', __name__, url_prefix='/settings')
+
+@settings.route('/admins')
+@login_required
+def admins():
+    # TODO get data from database
+    admins = [
+        {'name': 'Admin A', 'email': 'profA@uci.edu'},
+        {'name': 'Staff B', 'email': 'staffB@uci.edu'},
+        {'name': 'Staff C', 'email': 'staffC@uci.edu'}
+    ]
+    users = [
+        {'name': 'User A'},
+        {'name': 'User B'},
+        {'name': 'User C'}
+    ]
+    return render_template(
+        'settings/admins.html',
+        admins=admins,
+        current_user=admins[0],
+        users=users
+    )
+
+@settings.route('/point-policy')
+@login_required
+def point_policy():
+    # TODO get data from database
+    rules = [
+        {'name': 'Rule 1', 'point_value': 1},
+        {'name': 'Rule 2', 'point_value': 0.5},
+        {'name': 'Rule 3', 'point_value': 1.5}
+    ]
+    return render_template('settings/point-policy.html', rules=rules)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 attrs==22.1.0
+blinker==1.5
 cachetools==5.2.0
 certifi==2022.9.24
 charset-normalizer==2.1.1
 click==8.1.3
+colorama==0.4.6
 Flask==2.2.2
 google-auth==2.12.0
 google-auth-oauthlib==0.5.3

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,51 @@
+import pytest
+from flask import template_rendered
+
+from management_app import create_app
+
+@pytest.fixture
+def app():
+    app = create_app({
+        'TESTING': True,
+    })
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def mock_login(client):
+  # Enable login auth
+  with client.session_transaction() as session:
+      session['google_id'] = ''
+
+def captured_templates(app, recorded, **extra):
+    def record(sender, template, context):
+        recorded.append((template, context))
+    return template_rendered.connected_to(record, app)
+
+def test_get_admins_template(app, client):
+    mock_login(client)
+    templates = []
+    with captured_templates(app, templates):
+        response = client.get('/settings/admins')
+        assert response.status_code == 200
+        assert len(templates) == 1
+        template, context = templates[0]
+        assert template.name == 'settings/admins.html'
+        # TODO use data from test database for expected context values
+        assert len(context['admins']) == 3
+        assert context['current_user'] == context['admins'][0]
+        assert len(context['users']) == 3
+
+def test_get_point_policy_template(app, client):
+    mock_login(client)
+    templates = []
+    with captured_templates(app, templates):
+        response = client.get('/settings/point-policy')
+        assert response.status_code == 200
+        assert len(templates) == 1
+        template, context = templates[0]
+        assert template.name == 'settings/point-policy.html'
+        # TODO use data from test database for expected context values
+        assert len(context['rules']) == 3


### PR DESCRIPTION
This pull request adds the admin settings templates and tests for rendering those templates.

Additional Comments:
- Took out the Manage Admins option from the account menu in the side bar since managing admins is not a common action
- Adds new dependencies for tests