### PR TITLE
Update faculty page template style and content

### DIFF
--- a/management_app/templates/base.html
+++ b/management_app/templates/base.html
@@ -54,7 +54,7 @@
         </div>
       </nav>
 
-      <section class="content">
+      <section class="content container">
         <header class="d-flex gap-3">
           <h1>{% block header %}{% endblock %}</h1>
           {% block header_content %}{% endblock %}

--- a/management_app/templates/faculty/index.html
+++ b/management_app/templates/faculty/index.html
@@ -4,117 +4,127 @@
 {% block header %}Faculty{% endblock %}
 
 {% block content %}
-  <div class="row" style="margin: 20px 0;">
-    <div class="col d-inline-flex">
-      <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
-        <i class="fa-solid fa-download"></i>
-        Import Changes
-      </button>
-      <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h1 class="modal-title fs-5" id="exampleModalLabel">Add and/or edit faculty using the import template and upload it here.</h1>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-              <div class="row" style="margin: 10px 0;">
-                <div class="col">
-                  <a href="{{ url_for('faculty.download_file', filename='users_template.xlsx') }}">
-                    <button type="button" class="btn btn-primary">
-                      <i class="fa-solid fa-download"></i>
-                      Download Users Data Template
-                    </button>
-                  </a>
-                </div>
-              </div>
-              <div class="row" style="margin: 10px 0;">
-                <div class="col">
-                  <a href="{{ url_for('faculty.download_file', filename='professors_point_info_template.xlsx') }}">
-                    <button type="button" class="btn btn-primary">
-                      <i class="fa-solid fa-download"></i>
-                      Download Professor Point Info Data Template
-                    </button>
-                  </a>
-                </div>
-              </div>
-              <div class="row" style="margin: 10px 0;">
-                <div class="col">
-                  <button type="button" class="btn btn-outline-primary">
-                    Choose File to Upload
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-              <!-- ToDo: Only Enable import changes button after user uploades the file -->
-              <button type="button" class="btn btn-primary" disabled>Import Changes</button>
-            </div>
+<div class="row">
+  <div class="col-2">
+    <div class="d-flex">
+      <label class="align-self-center" for="yearSelect">Year:&nbsp;</label>
+      <select class="form-select align-self-center" id="yearSelect" aria-label="Year Select">
+        <option selected>2022-2023</option>
+        <option selected>2021-2022</option>
+      </select>
+    </div>
+  </div>
+  <div class="col-10">
+    <div class="d-grid justify-content-end">
+      <div class="d-inline-flex">
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#importChange">
+          <i class="fa-solid fa-download"></i>
+          Import Changes
+        </button>
+        <div class="dropdown" style="margin-left: 20px;">
+          <button class="btn btn-secondary fw-bold" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            ⋮
+          </button>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="#"><i class="fa-solid fa-plus"></i> Add Faculty Member</a></li>
+            <!-- TODO: Rollback only shows after upload in current session -->
+            <li><a class="dropdown-item" href="#"><i class="fa-solid fa-rotate-right"></i> Rollback Previous Change</a></li>
+          </ul>
+        </div>
+      </div>
+  </div>
+</div>
+
+</div>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Email</th>
+      <th scope="col">Role</th>
+      <th scope="col">Required Teaching Points</th>
+      <th scope="col">Previous Year Teaching Point Balance</th>
+      <th scope="col">Estimated End of Year Teaching Point Balance</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for faculty in faculties %}
+      <tr>
+        <th scope="row">{{ faculty['name'] }}</th>
+        <td>{{ faculty['email'] }}</td>
+        <td>{{ faculty['role'] }}</td>
+        <td>{{ faculty['required_point'] }}</td>
+        <td>{{ faculty['prev_balance'] }}</td>
+        <td>{{ faculty['estimated_balance'] }}</td>
+        <td>
+          <div class="dropdown">
+            <button class="btn btn-secondary fw-bold" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              ⋮
+            </button>
+            <ul class="dropdown-menu">
+              <li>
+                <a class="dropdown-item" href="#"><i class="fa-solid fa-pen-to-square"></i> Edit</a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="#"><i class="fa-solid fa-trash""></i></i> Delete</a>
+              </li>
+            </ul>
+          </div>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<div class="modal fade" id="importChange" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="importChangeLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="importChangeLabel">Add and/or edit faculty using the import template and upload it here.</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="row" style="margin: 10px 0;">
+          <div class="col">
+            <a href="{{ url_for('faculty.download_file', filename='users_template.xlsx') }}">
+              <button type="button" class="btn btn-primary">
+                <i class="fa-solid fa-download"></i>
+                Download Users Data Template
+              </button>
+            </a>
+          </div>
+        </div>
+        <div class="row" style="margin: 10px 0;">
+          <div class="col">
+            <a href="{{ url_for('faculty.download_file', filename='professors_point_info_template.xlsx') }}">
+              <button type="button" class="btn btn-primary">
+                <i class="fa-solid fa-download"></i>
+                Download Professor Point Info Data Template
+              </button>
+            </a>
+          </div>
+        </div>
+        <div class="row" style="margin: 10px 0;">
+          <div class="col">
+            <button type="button" class="btn btn-outline-primary">
+              Upload users template OR professor point info template
+            </button>
           </div>
         </div>
       </div>
-      <div class="dropdown" style="margin-left: 20px;">
-        <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-          Actions
-        </button>
-        <ul class="dropdown-menu">
-          <li><a class="dropdown-item" href="#"><i class="fa-solid fa-plus"></i>Add Faculty Member</a></li>
-          <!-- TODO: Rollback only shows after upload in current session -->
-          <li><a class="dropdown-item" href="#"><i class="fa-solid fa-rotate-right"></i>Rollback Previous Change</a></li>
-        </ul>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <!-- ToDo: Only Enable import changes button after user uploades the file -->
+        <button type="button" class="btn btn-primary" disabled>Import Changes</button>
       </div>
     </div>
   </div>
-
-  <div class="row" style="margin: 20px 0;">
-    <div class="col">
-      <table class="table">
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">Email</th>
-            <th scope="col">Role</th>
-            <th scope="col">Required Teaching Points</th>
-            <th scope="col">Previous Year Teaching Point Balance</th>
-            <th scope="col">Estimated End of Year Teaching Point Balance</th>
-            <th scope="col"></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for faculty in faculties %}
-            <tr>
-              <th scope="row">{{ faculty['name'] }}</th>
-              <td>{{ faculty['email'] }}</td>
-              <td>{{ faculty['role'] }}</td>
-              <td>{{ faculty['required_point'] }}</td>
-              <td>{{ faculty['prev_balance'] }}</td>
-              <td>{{ faculty['estimated_balance'] }}</td>
-              <td>
-                <div class="dropdown">
-                  <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                    Edit/Delete
-                  </button>
-                  <ul class="dropdown-menu">
-                    <li>
-                      <a class="dropdown-item" href="#"><i class="fa-solid fa-pen-to-square"></i>Edit</a>
-                    </li>
-                    <li>
-                      <a class="dropdown-item" href="#"><i class="fa-solid fa-trash""></i></i>Delete</a>
-                    </li>
-                  </ul>
-                </div>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  // console.log("We can write JavaScript here in the future");
 </script>
 {% endblock scripts %}

--- a/management_app/templates/settings/admins.html
+++ b/management_app/templates/settings/admins.html
@@ -24,96 +24,94 @@
 {% endblock %}
 
 {% block content %}
-  <div class="container">
-    <div class="d-grid justify-content-end">
-      <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addModal">+ Add Admin</button>
-    </div>
-    <table class="table">
-      <thead>
-        <tr>
-          <th scope="col">Name</th>
-          <th scope="col">Email</th>
-          <th scope="col"></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for admin in admins %}
-          <tr>
-            <th scope="row">{{admin['name']}} {% if admin == current_user %}<span class="badge text-bg-primary">You</span>{% endif %}</th>
-            <td>{{admin['email']}}</td>
-            <td>
-              <div class="dropdown d-grid justify-content-end">
-                <button class="btn btn-secondary fw-bold" type="button" data-bs-toggle="dropdown" aria-expanded="false">⋮</button>
-                <ul class="dropdown-menu">
-                  <li>
-                    <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="{{'#deleteModalSelf' if admin == current_user else '#deleteModal'}}">
-                      <i class="fa-solid fa-trash"></i></i> Delete
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <div class="modal fade" id="addModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addModalTitle" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h1 class="modal-title fs-5" id="addModalTitle">Add Admin</h1>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+<div class="d-grid justify-content-end">
+  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addModal">+ Add Admin</button>
+</div>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Email</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for admin in admins %}
+      <tr>
+        <th scope="row">{{admin['name']}} {% if admin == current_user %}<span class="badge text-bg-primary">You</span>{% endif %}</th>
+        <td>{{admin['email']}}</td>
+        <td>
+          <div class="dropdown d-grid justify-content-end">
+            <button class="btn btn-secondary fw-bold" type="button" data-bs-toggle="dropdown" aria-expanded="false">⋮</button>
+            <ul class="dropdown-menu">
+              <li>
+                <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="{{'#deleteModalSelf' if admin == current_user else '#deleteModal'}}">
+                  <i class="fa-solid fa-trash"></i></i> Delete
+                </button>
+              </li>
+            </ul>
           </div>
-          <div class="modal-body">
-            <label for="userSelect">Select a user to make an admin</label>
-            <select class="form-select" id="userSelect" aria-label="User Selection">
-              <option selected>Select a user</option>
-              {% for user in users %}
-                <option value="{{user['name']}}">{{user['name']}}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            <!-- TODO enable button when a user is selected -->
-            <button type="button" class="btn btn-primary" disabled>Add Admin</button>
-          </div>
-        </div>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<div class="modal fade" id="addModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addModalTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="addModalTitle">Add Admin</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-    </div>
-    <div class="modal fade" id="deleteModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="deleteModalTitle" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h1 class="modal-title fs-5" id="deleteModalTitle">Delete Admin</h1>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-            <p>Are you sure you want to delete this admin?</p>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
-            <button type="button" class="btn btn-primary">Yes</button>
-          </div>
-        </div>
+      <div class="modal-body">
+        <label for="userSelect">Select a user to make an admin</label>
+        <select class="form-select" id="userSelect" aria-label="User Selection">
+          <option selected>Select a user</option>
+          {% for user in users %}
+            <option value="{{user['name']}}">{{user['name']}}</option>
+          {% endfor %}
+        </select>
       </div>
-    </div>
-    <div class="modal fade" id="deleteModalSelf" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="deleteModalSelfTitle" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h1 class="modal-title fs-5" id="deleteModalSelfTitle">Delete My Account</h1>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-            <p>Are you sure you want to delete your account? This action cannot be undone.</p>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
-            <button type="button" class="btn btn-primary">Yes</button>
-          </div>
-        </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <!-- TODO enable button when a user is selected -->
+        <button type="button" class="btn btn-primary" disabled>Add Admin</button>
       </div>
     </div>
   </div>
+</div>
+<div class="modal fade" id="deleteModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="deleteModalTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="deleteModalTitle">Delete Admin</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to delete this admin?</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+        <button type="button" class="btn btn-primary">Yes</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="deleteModalSelf" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="deleteModalSelfTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="deleteModalSelfTitle">Delete My Account</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to delete your account? This action cannot be undone.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+        <button type="button" class="btn btn-primary">Yes</button>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/management_app/templates/settings/point-policy.html
+++ b/management_app/templates/settings/point-policy.html
@@ -24,22 +24,20 @@
 {% endblock %}
 
 {% block content %}
-  <div class="container">
-    <table class="table">
-      <thead>
-        <tr>
-          <th scope="col">Rule</th>
-          <th scope="col">Point Value</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for rule in rules %}
-          <tr>
-            <th scope="row">{{rule['name']}}</th>
-            <td>{{rule['point_value']}}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Rule</th>
+      <th scope="col">Point Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for rule in rules %}
+      <tr>
+        <th scope="row">{{rule['name']}}</th>
+        <td>{{rule['point_value']}}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/tests/test_faculty.py
+++ b/tests/test_faculty.py
@@ -1,7 +1,5 @@
 import os
-import tempfile
 import pytest
-from flask import session
 
 from management_app import create_app
 


### PR DESCRIPTION
This pull request is a small update for the faculty page template HTML/CSS based on Bootstrap. The main changes are:
- Use Bootstrap container CSS in the base template and apply it to the current faculty & settings page
- Update faculty page  import change modal to central and static modal
- Update wording of pop-up import change modal

Note that for now the _Year_ display on the page is hard-coded and will update when integrating with API.