### PR TITLE
Enable admin to upload templates to Flask local server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ htmlcov/
 .coverage
 .coverage.*
 *,cover
+
+management_app/static/upload_files/*

--- a/management_app/schema.sql
+++ b/management_app/schema.sql
@@ -1,11 +1,11 @@
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS users_status;
 DROP TABLE IF EXISTS professors_point_info;
 DROP TABLE IF EXISTS courses;
 DROP TABLE IF EXISTS scheduled_teaching;
 DROP TABLE IF EXISTS exceptions;
 DROP TABLE IF EXISTS points_constant;
 DROP TABLE IF EXISTS logs;
-
 
 CREATE TABLE users (
   user_id INTEGER PRIMARY KEY, -- AUTOINCREMENT

--- a/management_app/templates/faculty/index.html
+++ b/management_app/templates/faculty/index.html
@@ -81,44 +81,48 @@
 <div class="modal fade" id="importChange" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="importChangeLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
-      <div class="modal-header">
-        <h1 class="modal-title fs-5" id="importChangeLabel">Add and/or edit faculty using the import template and upload it here.</h1>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <div class="row" style="margin: 10px 0;">
-          <div class="col">
-            <a href="{{ url_for('faculty.download_file', filename='users_template.xlsx') }}">
-              <button type="button" class="btn btn-primary">
-                <i class="fa-solid fa-download"></i>
-                Download Users Data Template
-              </button>
-            </a>
+      <form method="POST" action="/faculty/upload" enctype="multipart/form-data">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5" id="importChangeLabel">Add and/or edit faculty using the import template and upload it here.</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="row" style="margin: 10px 0;">
+            <div class="col">
+              <a href="{{ url_for('faculty.download_template', filename='users_template.xlsx') }}">
+                <button type="button" class="btn btn-primary">
+                  <i class="fa-solid fa-download"></i>
+                  Download Users Data Template
+                </button>
+              </a>
+            </div>
+          </div>
+          <div class="row" style="margin: 10px 0;">
+            <div class="col">
+              <a href="{{ url_for('faculty.download_template', filename='professors_point_info_template.xlsx') }}">
+                <button type="button" class="btn btn-primary">
+                  <i class="fa-solid fa-download"></i>
+                  Download Professor Point Info Data Template
+                </button>
+              </a>
+            </div>
+          </div>
+          <div class="row" style="margin: 40px 0;">
+            <div class="col">
+              <div class="input-group mb-3">
+                <p>Upload users template OR professor point info template</p>
+                <div>
+                  <input type="file" name="facultyTemplate" class="form-control" id="uploadFacultyTemplate">
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        <div class="row" style="margin: 10px 0;">
-          <div class="col">
-            <a href="{{ url_for('faculty.download_file', filename='professors_point_info_template.xlsx') }}">
-              <button type="button" class="btn btn-primary">
-                <i class="fa-solid fa-download"></i>
-                Download Professor Point Info Data Template
-              </button>
-            </a>
-          </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary" id="submitFacultyTemplate" disabled>Import Changes</button>
         </div>
-        <div class="row" style="margin: 10px 0;">
-          <div class="col">
-            <button type="button" class="btn btn-outline-primary">
-              Upload users template OR professor point info template
-            </button>
-          </div>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <!-- ToDo: Only Enable import changes button after user uploades the file -->
-        <button type="button" class="btn btn-primary" disabled>Import Changes</button>
-      </div>
+      </form>
     </div>
   </div>
 </div>
@@ -126,5 +130,13 @@
 
 {% block scripts %}
 <script>
+  const templateUploadInput = document.getElementById("uploadFacultyTemplate");
+  const templateSubmitButton = document.getElementById("submitFacultyTemplate")
+  templateUploadInput.onchange = function() {
+  const input = this.files[0];
+  if (input) {
+    templateSubmitButton.disabled = false;
+  }
+};
 </script>
 {% endblock scripts %}

--- a/management_app/views/faculty.py
+++ b/management_app/views/faculty.py
@@ -1,9 +1,10 @@
-from flask import (Blueprint, render_template, send_from_directory)
+from flask import Flask, Blueprint, send_from_directory, render_template, request, redirect, url_for
+from werkzeug.utils import secure_filename
 
 from management_app.views.auth import login_required
+from management_app.views.utils import download_file, upload_file, remove_upload_file
 
 faculty = Blueprint('faculty', __name__, url_prefix='/faculty')
-
 
 @faculty.route('/')
 @login_required
@@ -22,6 +23,20 @@ def index():
 
 @faculty.route('/data-templates/<filename>')
 @login_required
-def download_file(filename):
-    path = 'static/data_templates'
-    return send_from_directory(path, filename, as_attachment=True)
+def download_template(filename):
+    return download_file(filename)
+
+
+@faculty.route('/upload', methods=['POST'])
+@login_required
+def upload_user_template():
+    if (request.method == 'POST'):
+        file = request.files['facultyTemplate']
+        filename = secure_filename(file.filename)
+        upload_file(file)
+
+        # TODO: process spreadsheet and store in database
+
+        remove_upload_file(file)
+
+        return redirect(url_for('faculty.index'))

--- a/management_app/views/utils.py
+++ b/management_app/views/utils.py
@@ -1,0 +1,36 @@
+import os
+from os.path import join, dirname
+from flask import send_from_directory
+from werkzeug.utils import secure_filename
+
+BASE_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+UPLOAD_FOLDER = 'static/upload_files'
+DOWNLOAD_FOLDER = 'static/data_templates'
+ALLOWED_EXTENSIONS = set(['xlsx', 'xls'])
+
+def download_file(filename):
+    return send_from_directory(DOWNLOAD_FOLDER, filename, as_attachment=True)
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+def get_upload_filepath(filename):
+    return os.path.realpath(os.path.join(BASE_DIR, UPLOAD_FOLDER, filename))
+
+def upload_file(file):
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        save_location = get_upload_filepath(filename)
+        if (save_location.startswith(BASE_DIR)):
+            file.save(save_location)
+            # TODO: Call logs API later
+            print('Upload {} successfully'.format(filename))
+    return
+
+def remove_upload_file(file):
+    filename = secure_filename(file.filename)
+    save_location = get_upload_filepath(filename)
+    os.remove(save_location)
+    # TODO: Call logs API later
+    print('Remove {} successfully'.format(filename))
+    return


### PR DESCRIPTION
This pull request enables the admin to upload templates to Flask local server.
- The files will be removed after we process template files and store data in the database.
- Also extract the download, upload, and remove functions in `utils.py` for future re-use.

Note: will work on processing files to the database in a separate pull request.