### PR TITLE
Enable admin to view faculty point breakdown and offering info

### DIFF
--- a/management_app/templates/faculty/faculty-dashboard.html
+++ b/management_app/templates/faculty/faculty-dashboard.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block title %}Faculty{% endblock %}
-{% block header %}Hi {{ g.user['user_name'] }}{% endblock %}
+{% block header %}{{ faculty_name }}{% endblock %}
 
 {% block content %}
 <div class="col-3 mb-3">
@@ -41,10 +41,8 @@
       {% for e in exceptions %}
         <li>{{ e['exception_category'] }}: {{ e['points'] }} points {% if e['message'] %}(Reason: {{ e['message'] }}){% endif %}</li>
       {% endfor %}
-      </ul>
-      {% else %}
-      0
       {% endif %}
+      </ul>
     </li>
   </ul>
 
@@ -79,7 +77,7 @@
         <td>{{ offering['course_title'] }}</td>
         <td>{{ offering['units'] }}</td>
         <td>{{ offering['course_level'] }}</td>
-        <td>{{ offering['enrollment'] }}</td>
+        <td>{% if offering['enrollment'] == -1 %} - {% else %} {{ offering['enrollment'] }} {% endif %}</td>
         <td>{% if offering['offload_or_recall_flag'] == 1 %} Yes {% else %} No {% endif %}</td>
         <td>{{ offering['teaching_point_val'] }}</td>
       </tr>

--- a/management_app/templates/faculty/index.html
+++ b/management_app/templates/faculty/index.html
@@ -70,7 +70,9 @@
   <tbody>
     {% for faculty in faculties %}
       <tr class="{% if faculty['profile_status'] and faculty['profile_status']['active_status'] == 0 %}table-secondary{% endif %}">
-        <th scope="row">{{ faculty['name'] }}</th>
+        <th scope="row">
+          <a href="{{url_for('faculty.point_breakdown', id=faculty['user_id'])}}">{{ faculty['name'] }}</a>
+        </th>
         <td>{{ faculty['email'] }}</td>
         <td>
           {% if faculty['profile_status'] %}


### PR DESCRIPTION
Main change:
- Add breakdown of point info route for admin view

The admin also needs to view the breakdown, so I added the same rendering template as the regular faculty user login page for the admin. The difference is we used a different route to render the template because the admin needs to get a specific user_id instead of a single global user.